### PR TITLE
Code changes in documentation and index

### DIFF
--- a/content/docs/learn/quickstart/scala.md
+++ b/content/docs/learn/quickstart/scala.md
@@ -138,7 +138,7 @@ import io.circe.parser.decode
 
 private final case class Book(name: String, author: String, summary: String) derives ScalaSerialDescriptor, Decoder
 
-def summarizeBook(title: String, author: String)(using scope: AIScope): Book =
+def summarizeBook(title: String, author: String): AI[Book] =
   prompt(s"$title by $author summary.")
 
 @main def runBook: Unit =
@@ -171,12 +171,11 @@ and make its response part of the context. One such agent is `search`, which use
 search service to enrich that context.
 
 ```scala
-import com.xebia.functional.xef.scala.agents.DefaultSearch
 import com.xebia.functional.xef.scala.auto.*
+import com.xebia.functional.xef.scala.agents.DefaultSearch
 import com.xebia.functional.xef.scala.auto.ScalaSerialDescriptorContext.given
-import io.circe.Decoder
 
-private def getQuestionAnswer(question: String)(using scope: AIScope): List[String] =
+private def getQuestionAnswer(question: String): AI[List[String]] =
   contextScope(DefaultSearch.search("Weather in Cádiz, Spain")) {
     promptMessage(question)
   }
@@ -191,7 +190,7 @@ private def getQuestionAnswer(question: String)(using scope: AIScope): List[Stri
 
 The underlying mechanism of the context is a _vector store_, a data structure which
 saves a set of strings, and is able to find those similar to another given one.
-By default xef.ai uses an _in-memory_ vector store, since it provides maximum
+By default, xef.ai uses an _in-memory_ vector store, since it provides maximum
 compatibility across platforms. However, if you foresee your context growing above
 the hundreds of elements, you may consider switching to another alternative, like
 Lucene or PostgreSQL.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,6 +44,7 @@ export default function Home(): JSX.Element {
                   {`final case class Population(size: Int, description: String) derives ScalaSerialDescriptor, Decoder
 
                   final case class Image(description: String, url: String) derives ScalaSerialDescriptor, Decoder
+
                   @main def runPopulation: Unit =
 ai {
   val cadiz: Population = prompt("Population of Cádiz, Spain.")

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,11 +41,16 @@ export default function Home(): JSX.Element {
             <Tabs>
               <TabItem value="scala" label="Scala">
                 <CodeBlock language="scala" showLineNumbers>
-                  {`@main def runPopulation: Unit =
+                  {`final case class Population(size: Int, description: String) derives ScalaSerialDescriptor, Decoder
+
+                  final case class Image(description: String, url: String) derives ScalaSerialDescriptor, Decoder
+                  @main def runPopulation: Unit =
 ai {
   val cadiz: Population = prompt("Population of Cádiz, Spain.")
   val seattle: Population = prompt("Population of Seattle, WA.")
   println(s"The population of Cádiz is \${cadiz.size} and the population of Seattle is \${seattle.size}")
+  val img: Image = image("A hybrid city of Cádiz, Spain and Seattle, US.")
+  println(s"Image \${img.description} available at \${img.url}")
 }`}
                 </CodeBlock>
               </TabItem>


### PR DESCRIPTION
- [x] Making Scala example equals as Kotlin example in the `Discover its potential` section.
- [x] Using `AI[A]` type alias instead of `(using scope: AIScope): A` in scala examples. 