### PR TITLE
Use new Docusaurus GTM plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,7 +70,7 @@ const createConfig = async () => {
             ],
           },
 
-          googleAnalytics: {
+          gtag: {
             trackingID: 'G-CXGGXNMKQ9',
             anonymizeIP: true,
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@docusaurus/core": "2.4.0",
-        "@docusaurus/plugin-google-analytics": "^2.4.1",
+        "@docusaurus/plugin-google-gtag": "2.4.1",
         "@docusaurus/preset-classic": "2.4.0",
         "@docusaurus/theme-mermaid": "2.4.0",
         "@easyops-cn/docusaurus-search-local": "0.35.0",
@@ -2383,10 +2383,10 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics": {
+    "node_modules/@docusaurus/plugin-google-gtag": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.1.tgz",
-      "integrity": "sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.1.tgz",
+      "integrity": "sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==",
       "dependencies": {
         "@docusaurus/core": "2.4.1",
         "@docusaurus/types": "2.4.1",
@@ -2401,7 +2401,7 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/core": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
       "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
@@ -2489,7 +2489,7 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/cssnano-preset": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/cssnano-preset": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
       "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
@@ -2503,7 +2503,7 @@
         "node": ">=16.14"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/logger": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/logger": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.1.tgz",
       "integrity": "sha512-5h5ysIIWYIDHyTVd8BjheZmQZmEgWDR54aQ1BX9pjFfpyzFo5puKXKYrYJXbjEHGyVhEzmB9UXwbxGfaZhOjcg==",
@@ -2515,7 +2515,7 @@
         "node": ">=16.14"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/mdx-loader": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/mdx-loader": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.1.tgz",
       "integrity": "sha512-4KhUhEavteIAmbBj7LVFnrVYDiU51H5YWW1zY6SmBSte/YLhDutztLTBE0PQl1Grux1jzUJeaSvAzHpTn6JJDQ==",
@@ -2546,7 +2546,7 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.1.tgz",
       "integrity": "sha512-0R+cbhpMkhbRXX138UOc/2XZFF8hiZa6ooZAEEJFp5scytzCw4tC1gChMFXrpa3d2tYE6AX8IrOEpSonLmfQuQ==",
@@ -2565,7 +2565,7 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.1.tgz",
       "integrity": "sha512-1lvEZdAQhKNht9aPXPoh69eeKnV0/62ROhQeFKKxmzd0zkcuE/Oc5Gpnt00y/f5bIsmOsYMY7Pqfm/5rteT5GA==",
@@ -2599,7 +2599,7 @@
         }
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils-common": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-common": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.1.tgz",
       "integrity": "sha512-bCVGdZU+z/qVcIiEQdyx0K13OC5mYwxhSuDUR95oFbKVuXYRrTVrwZIqQljuo1fyJvFTKHiL9L9skQOPokuFNQ==",
@@ -2618,7 +2618,7 @@
         }
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/utils-validation": {
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-validation": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.1.tgz",
       "integrity": "sha512-unII3hlJlDwZ3w8U+pMO3Lx3RhI4YEbY3YNsQj4yzrkZzlpqZOLuAiZK2JyULnD+TKbceKU0WyWkQXtYbLNDFA==",
@@ -2631,24 +2631,6 @@
       },
       "engines": {
         "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
-      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
-      "dependencies": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
@@ -2723,6 +2705,24 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
       "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-gtag": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
       "dependencies": {
         "@docusaurus/core": "2.4.0",
         "@docusaurus/types": "2.4.0",
@@ -17351,10 +17351,10 @@
         "tslib": "^2.4.0"
       }
     },
-    "@docusaurus/plugin-google-analytics": {
+    "@docusaurus/plugin-google-gtag": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.1.tgz",
-      "integrity": "sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.1.tgz",
+      "integrity": "sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==",
       "requires": {
         "@docusaurus/core": "2.4.1",
         "@docusaurus/types": "2.4.1",
@@ -17544,17 +17544,6 @@
         }
       }
     },
-    "@docusaurus/plugin-google-gtag": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
-      "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
-      "requires": {
-        "@docusaurus/core": "2.4.0",
-        "@docusaurus/types": "2.4.0",
-        "@docusaurus/utils-validation": "2.4.0",
-        "tslib": "^2.4.0"
-      }
-    },
     "@docusaurus/plugin-google-tag-manager": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.0.tgz",
@@ -17606,6 +17595,17 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.0.tgz",
           "integrity": "sha512-uGUzX67DOAIglygdNrmMOvEp8qG03X20jMWadeqVQktS6nADvozpSLGx4J0xbkblhJkUzN21WiilsP9iVP+zkw==",
+          "requires": {
+            "@docusaurus/core": "2.4.0",
+            "@docusaurus/types": "2.4.0",
+            "@docusaurus/utils-validation": "2.4.0",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/plugin-google-gtag": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.0.tgz",
+          "integrity": "sha512-adj/70DANaQs2+TF/nRdMezDXFAV/O/pjAbUgmKBlyOTq5qoMe0Tk4muvQIwWUmiUQxFJe+sKlZGM771ownyOg==",
           "requires": {
             "@docusaurus/core": "2.4.0",
             "@docusaurus/types": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.4.0",
-    "@docusaurus/plugin-google-analytics": "2.4.1",
+    "@docusaurus/plugin-google-gtag": "2.4.1",
     "@docusaurus/preset-classic": "2.4.0",
     "@docusaurus/theme-mermaid": "2.4.0",
     "@easyops-cn/docusaurus-search-local": "0.35.0",


### PR DESCRIPTION
This PR updates the Docusaurus Analytics plugin to start using the Google Tag Manager plugin, as explained here:

https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics

https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag