### PR TITLE
[DOC] - Fix url in more example page

### DIFF
--- a/content/docs/learn/examples.md
+++ b/content/docs/learn/examples.md
@@ -7,4 +7,4 @@ description: Explore all that xef.ai offers
 
 # More examples
 
-You can also have a look at the [examples](https://github.com/xebia-functional/xef/tree/main/examples/kotlin/src/main/kotlin/com/xebia/functional/xef) to have a feeling of how using the library looks like.
+You can also have a look at the [examples](https://github.com/xebia-functional/xef/tree/main/examples/src/main/kotlin/com/xebia/functional/xef/conversation) to have a feeling of how using the library looks like.


### PR DESCRIPTION
Fix link to github example 